### PR TITLE
Fixed "unexpected argument 'seed'" exception for ObstacleAvoidanceMir100.reset()

### DIFF
--- a/robo_gym/envs/mir100/mir100.py
+++ b/robo_gym/envs/mir100/mir100.py
@@ -433,7 +433,7 @@ class NoObstacleNavigationMir100Rob(NoObstacleNavigationMir100):
 class ObstacleAvoidanceMir100(Mir100Env):
     laser_len = 16
 
-    def reset(self, start_pose = None, target_pose = None):
+    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None) -> tuple[np.ndarray, dict[str, Any]]:
         """Environment reset.
 
         Args:
@@ -442,8 +442,15 @@ class ObstacleAvoidanceMir100(Mir100Env):
 
         Returns:
             np.array: Environment state.
+            dict: info
 
         """
+        super().reset(seed=seed)
+        if options is None:
+            options = {}
+        start_pose = options["start_pose"] if "start_pose" in options else None
+        target_pose = options["target_pose"] if "target_pose" in options else None
+
         self.elapsed_steps = 0
 
         self.prev_base_reward = None
@@ -492,7 +499,7 @@ class ObstacleAvoidanceMir100(Mir100Env):
         if not self.observation_space.contains(self.state):
             raise InvalidStateError()
 
-        return self.state
+        return self.state, {}
 
     def _reward(self, rs_state, action):
         reward = 0


### PR DESCRIPTION
Hello,

I am currently doing some research for integrating reinforcement learning for some ROS 2 robots at my university and this project seem quite promising given the capabilities it offers, so I firstly thank the authors for your hard work.

I was trying to run the `ObstacleAvoidanceMir100` environment in simulation mode, but the current implementation has a bug where calling the `reset()` function yields an "unexpected argument 'seed'" exception. This PR is a small patch that more-or-less replicates the function signature of the base `Mir100Env` class and thus patch that specific error.

I haven't properly ran the tests for this but this has been manually tested on my Windows machine using Docker containers and WSL 2 as the backend container engine, and with X11 forwarding. If anyone else is interested, I can share my development files to replicate my development environment.