### PR TITLE
Fixed Universal Robots Basic Avoidance simulation API inconsistencies

### DIFF
--- a/robo_gym/envs/ur/ur_avoidance_basic.py
+++ b/robo_gym/envs/ur/ur_avoidance_basic.py
@@ -139,17 +139,17 @@ class BasicAvoidanceUR(URBaseAvoidanceEnv):
 
         return reward, done, info
 
-    def step(self, action) -> Tuple[np.array, float, bool, dict]:
+    def step(self, action) -> Tuple[np.array, float, bool, bool, dict]:
         if type(action) == list: action = np.array(action)
 
         action = action.astype(np.float32)
-        
-        state, reward, done, info = super().step(action)
+
+        state, reward, done, truncated, info = super().step(action)
 
         self.prev_action = self.add_fixed_joints(action)
 
-        return state, reward, done, info
-    
+        return state, reward, done, truncated, info
+
 class BasicAvoidanceURSim(BasicAvoidanceUR, Simulation):
     cmd = "roslaunch ur_robot_server ur_robot_server.launch \
         world_name:=tabletop_sphere50.world \

--- a/robo_gym/envs/ur/ur_avoidance_basic.py
+++ b/robo_gym/envs/ur/ur_avoidance_basic.py
@@ -8,7 +8,7 @@ otherwise wait for the obstacle to move away before proceeding
 """
 from __future__ import annotations
 import numpy as np
-from typing import Tuple
+from typing import Tuple, Any
 from robo_gym_server_modules.robot_server.grpc_msgs.python import robot_server_pb2
 from robo_gym.envs.simulation_wrapper import Simulation
 from robo_gym.envs.ur.ur_base_avoidance_env import URBaseAvoidanceEnv
@@ -64,18 +64,22 @@ class BasicAvoidanceUR(URBaseAvoidanceEnv):
         return state_msg
 
 
-    def reset(self, joint_positions = JOINT_POSITIONS, fixed_object_position = None) -> np.ndarray:
+    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None) -> tuple[np.ndarray, dict[str, Any]]:
         """Environment reset.
 
-        Args:
+        options:
             joint_positions (list[6] or np.array[6]): robot joint positions in radians.
             fixed_object_position (list[3]): x,y,z fixed position of object
+
+        Returns:
+            np.array: Environment state.
+            dict: info
         """
         self.prev_action = np.zeros(6)
 
-        state = super().reset(joint_positions = joint_positions, fixed_object_position = fixed_object_position)   
+        initial_state, info = super().reset(seed=seed, options=options)
 
-        return state
+        return initial_state, info
 
     def reward(self, rs_state, action) -> Tuple[float, bool, dict]:
         env_state = self._robot_server_state_to_env_state(rs_state)

--- a/robo_gym/envs/ur/ur_avoidance_raad.py
+++ b/robo_gym/envs/ur/ur_avoidance_raad.py
@@ -93,9 +93,9 @@ class AvoidanceRaad2022UR(URBaseAvoidanceEnv):
             options = {}
         options["joint_positions"] = joint_positions
 
-        super_result = super().reset(seed=seed, options=options)
-            
-        return super_result
+        initial_state = super().reset(seed=seed, options=options)
+
+        return initial_state
 
     def step(self, action) -> Tuple[np.array, float, bool, bool, dict]:
         if type(action) == list: action = np.array(action)
@@ -103,8 +103,8 @@ class AvoidanceRaad2022UR(URBaseAvoidanceEnv):
         action = action.astype(np.float32)
         
         self.elapsed_steps_in_current_state += 1
-        
-        state, reward, done, info = super().step(action)
+
+        state, reward, done, truncated, info = super().step(action)
 
         # Check if waypoint was reached
         joint_positions = []
@@ -128,7 +128,7 @@ class AvoidanceRaad2022UR(URBaseAvoidanceEnv):
 
         self.prev_action = self.add_fixed_joints(action)
 
-        return state, reward, done, False, info
+        return state, reward, done, truncated, info
 
     def reward(self, rs_state, action) -> Tuple[float, bool, dict]:
         env_state = self._robot_server_state_to_env_state(rs_state)
@@ -322,9 +322,9 @@ class AvoidanceRaad2022TestUR(AvoidanceRaad2022UR):
 
         self.ep_n +=1
 
-        super_result = super().reset(seed=seed, options=options)
+        initial_state, info = super().reset(seed=seed, options=options)
 
-        return super_result
+        return initial_state, info
 
 class AvoidanceRaad2022TestURSim(AvoidanceRaad2022TestUR, Simulation):
     cmd = "roslaunch ur_robot_server ur_robot_server.launch \

--- a/robo_gym/envs/ur/ur_base_avoidance_env.py
+++ b/robo_gym/envs/ur/ur_base_avoidance_env.py
@@ -68,7 +68,7 @@ class URBaseAvoidanceEnv(URBaseEnv):
                 dict: info
 
         """
-        super(gym.Env).reset(seed=seed, options=options)
+        super(URBaseEnv, self).reset(seed=seed)
 
         self.elapsed_steps = 0
         if options is None:


### PR DESCRIPTION
Hello again,

This is a separate PR that mostly reflects the same-ish changes from #82, with the following fixes:
- "unexpected argument 'seed'" exception for `BasicAvoidanceUR.reset()`
- Attempting to call `BasicAvoidanceUR.step()` used the old Gym syntax
- Attempting to call `URBaseAvoidanceEnv.reset()` tried to call reset() from the parent of `gym.Env`, which does not exist

I haven't properly ran the tests for this but this has been manually tested with the following setup:

- Python 3.11
- Windows machine using Docker containers (WSL 2 backed)
- X11 forwarding via [VcXsrv (Windows X Server)](https://sourceforge.net/projects/vcxsrv/)

If anyone else is interested, I can share my development files to replicate my development environment.