### PR TITLE
Add loosely-typed API to construct roslaunch commands

### DIFF
--- a/robo_gym/envs/mir100/mir100.py
+++ b/robo_gym/envs/mir100/mir100.py
@@ -7,7 +7,7 @@ import numpy as np
 import gymnasium as gym
 from gymnasium import spaces, logger
 from gymnasium.utils import seeding
-from robo_gym.utils import utils, mir100_utils
+from robo_gym.utils import utils, mir100_utils, cmd_utils
 from robo_gym.utils.exceptions import InvalidStateError, RobotServerError
 import robo_gym_server_modules.robot_server.client as rs_client
 from robo_gym.envs.simulation_wrapper import Simulation
@@ -421,8 +421,12 @@ class NoObstacleNavigationMir100(Mir100Env):
         return reward, done, info
 
 class NoObstacleNavigationMir100Sim(Simulation, NoObstacleNavigationMir100):
-    cmd = "roslaunch mir100_robot_server sim_robot_server.launch"
     def __init__(self, ip=None, lower_bound_port=None, upper_bound_port=None, gui=False, **kwargs):
+        self.cmd = cmd_utils.construct_roslaunch_command(
+            module='mir100_robot_server',
+            launch_file='sim_robot_server.launch'
+        )
+
         Simulation.__init__(self, self.cmd, ip, lower_bound_port, upper_bound_port, gui, **kwargs)
         NoObstacleNavigationMir100.__init__(self, rs_address=self.robot_server_ip, **kwargs)
 
@@ -640,8 +644,15 @@ class ObstacleAvoidanceMir100(Mir100Env):
         self.sim_obstacles = [[x_0, y_0, yaw_0],[x_1, y_1, yaw_1],[x_2, y_2, yaw_2]]
 
 class ObstacleAvoidanceMir100Sim(Simulation, ObstacleAvoidanceMir100):
-    cmd = "roslaunch mir100_robot_server sim_robot_server.launch world_name:=lab_6x8.world"
     def __init__(self, ip=None, lower_bound_port=None, upper_bound_port=None, gui=False, **kwargs):
+        self.cmd = cmd_utils.construct_roslaunch_command(
+            module='mir100_robot_server',
+            launch_file='sim_robot_server.launch',
+            launch_args={
+                'world_name': 'lab_6x8.world'
+            }
+        )
+
         Simulation.__init__(self, self.cmd, ip, lower_bound_port, upper_bound_port, gui, **kwargs)
         ObstacleAvoidanceMir100.__init__(self, rs_address=self.robot_server_ip, **kwargs)
 

--- a/robo_gym/envs/ur/ur_avoidance_basic.py
+++ b/robo_gym/envs/ur/ur_avoidance_basic.py
@@ -9,6 +9,7 @@ otherwise wait for the obstacle to move away before proceeding
 from __future__ import annotations
 import numpy as np
 from typing import Tuple
+from robo_gym.utils import cmd_utils
 from robo_gym_server_modules.robot_server.grpc_msgs.python import robot_server_pb2
 from robo_gym.envs.simulation_wrapper import Simulation
 from robo_gym.envs.ur.ur_base_avoidance_env import URBaseAvoidanceEnv
@@ -147,20 +148,26 @@ class BasicAvoidanceUR(URBaseAvoidanceEnv):
         return state, reward, done, info
     
 class BasicAvoidanceURSim(BasicAvoidanceUR, Simulation):
-    cmd = "roslaunch ur_robot_server ur_robot_server.launch \
-        world_name:=tabletop_sphere50.world \
-        reference_frame:=base_link \
-        max_velocity_scale_factor:=0.2 \
-        action_cycle_rate:=20 \
-        rviz_gui:=false \
-        gazebo_gui:=true \
-        objects_controller:=true \
-        rs_mode:=1moving2points \
-        n_objects:=1.0 \
-        object_0_model_name:=sphere50 \
-        object_0_frame:=target"
     def __init__(self, ip=None, lower_bound_port=None, upper_bound_port=None, gui=False, ur_model='ur5', **kwargs):
-        self.cmd = self.cmd + ' ' + 'ur_model:=' + ur_model
+        self.cmd = cmd_utils.construct_roslaunch_command(
+            module='ur_robot_server',
+            launch_file='ur_robot_server.launch',
+            launch_args={
+                'world_name': 'tabletop_sphere50.world',
+                'reference_frame': 'base_link',
+                'max_velocity_scale_factor': 0.2,
+                'action_cycle_rate': 20,
+                'rviz_gui': False,
+                'gazebo_gui': True,
+                'objects_controller': True,
+                'rs_mode': '1moving2points',
+                'n_objects': 1.0,
+                'object_0_model_name': 'sphere50',
+                'object_0_frame': 'target',
+                'ur_model': ur_model
+            }
+        )
+
         Simulation.__init__(self, self.cmd, ip, lower_bound_port, upper_bound_port, gui, **kwargs)
         BasicAvoidanceUR.__init__(self, rs_address=self.robot_server_ip, ur_model=ur_model, **kwargs)
 

--- a/robo_gym/envs/ur/ur_avoidance_raad.py
+++ b/robo_gym/envs/ur/ur_avoidance_raad.py
@@ -11,6 +11,7 @@ import os, copy, json
 import numpy as np
 import gymnasium as gym
 from typing import Tuple, Any
+from robo_gym.utils import cmd_utils
 from robo_gym_server_modules.robot_server.grpc_msgs.python import robot_server_pb2
 from robo_gym.envs.simulation_wrapper import Simulation
 from robo_gym.envs.ur.ur_base_avoidance_env import URBaseAvoidanceEnv
@@ -263,20 +264,26 @@ class AvoidanceRaad2022UR(URBaseAvoidanceEnv):
         return np.array(temp)
 
 class AvoidanceRaad2022URSim(AvoidanceRaad2022UR, Simulation):
-    cmd = "roslaunch ur_robot_server ur_robot_server.launch \
-        world_name:=tabletop_sphere50.world \
-        reference_frame:=base_link \
-        max_velocity_scale_factor:=0.2 \
-        action_cycle_rate:=20 \
-        rviz_gui:=false \
-        gazebo_gui:=true \
-        objects_controller:=true \
-        rs_mode:=1moving2points \
-        n_objects:=1.0 \
-        object_0_model_name:=sphere50 \
-        object_0_frame:=target"
     def __init__(self, ip=None, lower_bound_port=None, upper_bound_port=None, gui=False, ur_model='ur5', **kwargs):
-        self.cmd = self.cmd + ' ' + 'ur_model:=' + ur_model
+        self.cmd = cmd_utils.construct_roslaunch_command(
+            module='ur_robot_server',
+            launch_file='ur_robot_server.launch',
+            launch_args={
+                'world_name': 'tabletop_sphere50.world',
+                'reference_frame': 'base_link',
+                'max_velocity_scale_factor': 0.2,
+                'action_cycle_rate': 20,
+                'rviz_gui': False,
+                'gazebo_gui': True,
+                'objects_controller': True,
+                'rs_mode': '1moving2points',
+                'n_objects': 1.0,
+                'object_0_model_name': 'sphere50',
+                'object_0_frame': 'target',
+                'ur_model': ur_model
+            }
+        )
+
         Simulation.__init__(self, self.cmd, ip, lower_bound_port, upper_bound_port, gui, **kwargs)
         AvoidanceRaad2022UR.__init__(self, rs_address=self.robot_server_ip, ur_model=ur_model, **kwargs)
 
@@ -327,21 +334,27 @@ class AvoidanceRaad2022TestUR(AvoidanceRaad2022UR):
         return super_result
 
 class AvoidanceRaad2022TestURSim(AvoidanceRaad2022TestUR, Simulation):
-    cmd = "roslaunch ur_robot_server ur_robot_server.launch \
-        world_name:=tabletop_sphere50.world \
-        reference_frame:=base_link \
-        max_velocity_scale_factor:=0.2 \
-        action_cycle_rate:=20 \
-        rviz_gui:=false \
-        gazebo_gui:=true \
-        objects_controller:=true \
-        rs_mode:=1moving2points \
-        n_objects:=1.0 \
-        object_trajectory_file_name:=splines_ur5 \
-        object_0_model_name:=sphere50 \
-        object_0_frame:=target"
     def __init__(self, ip=None, lower_bound_port=None, upper_bound_port=None, gui=False, ur_model='ur5', **kwargs):
-        self.cmd = self.cmd + ' ' + 'ur_model:=' + ur_model
+        self.cmd = cmd_utils.construct_roslaunch_command(
+            module='ur_robot_server',
+            launch_file='ur_robot_server.launch',
+            launch_args={
+                'world_name': 'tabletop_sphere50.world',
+                'reference_frame': 'base_link',
+                'max_velocity_scale_factor': 0.2,
+                'action_cycle_rate': 20,
+                'rviz_gui': False,
+                'gazebo_gui': True,
+                'objects_controller': True,
+                'rs_mode': '1moving2points',
+                'n_objects': 1.0,
+                'object_trajectory_file_name': 'splines_ur5',
+                'object_0_model_name': 'sphere50',
+                'object_0_frame': 'target',
+                'ur_model': ur_model
+            }
+        )
+
         Simulation.__init__(self, self.cmd, ip, lower_bound_port, upper_bound_port, gui, **kwargs)
         AvoidanceRaad2022TestUR.__init__(self, rs_address=self.robot_server_ip, ur_model=ur_model, **kwargs)
 

--- a/robo_gym/envs/ur/ur_base_env.py
+++ b/robo_gym/envs/ur/ur_base_env.py
@@ -4,7 +4,7 @@ import copy
 import numpy as np
 import gymnasium as gym
 from typing import Tuple, Any
-from robo_gym.utils import ur_utils
+from robo_gym.utils import cmd_utils, ur_utils
 from robo_gym.utils.exceptions import InvalidStateError, RobotServerError, InvalidActionError
 import robo_gym_server_modules.robot_server.client as rs_client
 from robo_gym_server_modules.robot_server.grpc_msgs.python import robot_server_pb2
@@ -379,16 +379,22 @@ class URBaseEnv(gym.Env):
 
 
 class EmptyEnvironmentURSim(URBaseEnv, Simulation):
-    cmd = "roslaunch ur_robot_server ur_robot_server.launch \
-        world_name:=empty.world \
-        reference_frame:=base_link \
-        max_velocity_scale_factor:=0.2 \
-        action_cycle_rate:=20 \
-        rviz_gui:=true \
-        gazebo_gui:=true \
-        rs_mode:=only_robot"
     def __init__(self, ip=None, lower_bound_port=None, upper_bound_port=None, gui=False, ur_model='ur5', **kwargs):
-        self.cmd = self.cmd + ' ' + 'ur_model:=' + ur_model
+        self.cmd = cmd_utils.construct_roslaunch_command(
+            module='ur_robot_server',
+            launch_file='ur_robot_server.launch',
+            launch_args={
+                'world_name': 'empty.world',
+                'reference_frame': 'base_link',
+                'max_velocity_scale_factor': 0.2,
+                'action_cycle_rate': 20,
+                'rviz_gui': True,
+                'gazebo_gui': True,
+                'rs_mode': 'only_robot',
+                'ur_model': ur_model,
+            }
+        )
+
         Simulation.__init__(self, self.cmd, ip, lower_bound_port, upper_bound_port, gui, **kwargs)
         URBaseEnv.__init__(self, rs_address=self.robot_server_ip, ur_model=ur_model, **kwargs)
 

--- a/robo_gym/envs/ur/ur_ee_positioning.py
+++ b/robo_gym/envs/ur/ur_ee_positioning.py
@@ -5,7 +5,7 @@ import gymnasium as gym
 from typing import Tuple, Any
 from scipy.spatial.transform import Rotation as R
 from robo_gym.utils.exceptions import InvalidStateError, RobotServerError
-from robo_gym.utils import utils
+from robo_gym.utils import utils, cmd_utils
 from robo_gym_server_modules.robot_server.grpc_msgs.python import robot_server_pb2
 from robo_gym.envs.simulation_wrapper import Simulation
 from robo_gym.envs.ur.ur_base_env import URBaseEnv
@@ -366,20 +366,26 @@ class EndEffectorPositioningUR(URBaseEnv):
 
         
 class EndEffectorPositioningURSim(EndEffectorPositioningUR, Simulation):
-    cmd = "roslaunch ur_robot_server ur_robot_server.launch \
-        world_name:=tabletop_sphere50_no_collision.world \
-        reference_frame:=base_link \
-        max_velocity_scale_factor:=0.1 \
-        action_cycle_rate:=10 \
-        rviz_gui:=true \
-        gazebo_gui:=true \
-        objects_controller:=true \
-        rs_mode:=1object \
-        n_objects:=1.0 \
-        object_0_model_name:=sphere50_no_collision \
-        object_0_frame:=target"
     def __init__(self, ip=None, lower_bound_port=None, upper_bound_port=None, gui=False, ur_model='ur5', **kwargs):
-        self.cmd = self.cmd + ' ' + 'ur_model:=' + ur_model
+        self.cmd = cmd_utils.construct_roslaunch_command(
+            module='ur_robot_server',
+            launch_file='ur_robot_server.launch',
+            launch_args={
+                'world_name': 'tabletop_sphere50_no_collision.world',
+                'reference_frame': 'base_link',
+                'max_velocity_scale_factor': 0.1,
+                'action_cycle_rate': 10,
+                'rviz_gui': True,
+                'gazebo_gui': True,
+                'objects_controller': True,
+                'rs_mode': '1object',
+                'n_objects': 1.0,
+                'object_0_model_name': 'sphere50_no_collision',
+                'object_0_frame': 'target',
+                'ur_model': ur_model
+            }
+        )
+
         Simulation.__init__(self, self.cmd, ip, lower_bound_port, upper_bound_port, gui, **kwargs)
         EndEffectorPositioningUR.__init__(self, rs_address=self.robot_server_ip, ur_model=ur_model, **kwargs)
 

--- a/robo_gym/utils/cmd_utils.py
+++ b/robo_gym/utils/cmd_utils.py
@@ -1,0 +1,30 @@
+from typing import Any
+import numpy as np
+
+def construct_roslaunch_command(module: str, launch_file: str, launch_args: dict[str, Any] = {}) -> str:
+    """Construct a full roslaunch command to run for simulations from a base command and its arguments.
+
+    Args:
+        base_cmd (string): The base roslaunch command containing the module and launch file
+        launch_args (float): y coordinate of the point.
+
+    Returns:
+        constructed_cmd (string): The fully constructed roslaunch command.
+
+    """
+
+    launch_args_merged = ''
+    for (name, value) in launch_args.items():
+        if type(value) == bool:
+            # roslaunch expects the lowercase version of Python's boolean values
+            value = 'true' if value else 'false'
+        elif type(value) in [int, float, np.number]:
+            # TODO: This is redundant (and will be removed later) but helpful to highlight that numeric conversions are supported
+            value = str(value)
+        else:
+            value = str(value)
+
+        launch_args_merged += f'{name}:={value} '
+
+    constructed_cmd = f'roslaunch {module} {launch_file} {launch_args_merged}'.strip()
+    return constructed_cmd

--- a/tests/robo-gym/utils/test_cmd_utils.py
+++ b/tests/robo-gym/utils/test_cmd_utils.py
@@ -1,0 +1,41 @@
+import pytest
+from robo_gym.utils import cmd_utils
+
+# Input command argument definitions
+BASIC_ARGS = {}
+
+COMMAND_ARGS_SIMPLE = {
+    'string_var1': 'string1',
+    'string_var2': 'string2'
+}
+
+COMMAND_ARGS_COMPLEX = {
+    'string_var': 'string',
+    'int_var': 6,
+    'float_var': 3.14,
+    'bool_var': True,
+}
+
+# Expected command string definitions (NOTE: indentation sensitive)
+EXP_BASIC_COMMAND = "roslaunch example_module_1 example_launch_1.launch"
+
+EXP_COMMAND_WITH_ARGS_SIMPLE = "roslaunch example_module_2 example_launch_2.launch \
+string_var1:=string1 \
+string_var2:=string2"
+
+EXP_COMMAND_WITH_ARGS_COMPLEX = "roslaunch example_module_3 example_launch_3.launch \
+string_var:=string \
+int_var:=6 \
+float_var:=3.14 \
+bool_var:=true"
+
+### correct_launch_commands ###
+test_correct_launch_commands = [
+    ('example_module_1', 'example_launch_1.launch', BASIC_ARGS, EXP_BASIC_COMMAND),
+    ('example_module_2', 'example_launch_2.launch', COMMAND_ARGS_SIMPLE, EXP_COMMAND_WITH_ARGS_SIMPLE),
+    ('example_module_3', 'example_launch_3.launch', COMMAND_ARGS_COMPLEX, EXP_COMMAND_WITH_ARGS_COMPLEX)
+]
+@pytest.mark.parametrize('module, launch_file, launch_args, expected_result', test_correct_launch_commands)
+def test_construct_roslaunch_command(module, launch_file, launch_args, expected_result):
+    constructed_cmd = cmd_utils.construct_roslaunch_command(module, launch_file, launch_args)
+    assert constructed_cmd == expected_result


### PR DESCRIPTION
Hello again,

I noticed there's been some activity on the repo and I wanted to add a minor QOL PR to how launch commands are constructed. I didn't like the idea of string concatenating complex arguments so I created `construct_roslaunch_command`, which is a simple command to take the ROS module, launch file and launch commands and create the launch command string.

The easiest comparision is shown below in `robo_gym/envs/ur/ur_avoidance_basic.py`:

### Before
```python
cmd = "roslaunch ur_robot_server ur_robot_server.launch \
        world_name:=tabletop_sphere50.world \
        reference_frame:=base_link \
        max_velocity_scale_factor:=0.2 \
        action_cycle_rate:=20 \
        rviz_gui:=false \
        gazebo_gui:=true \
        objects_controller:=true \
        rs_mode:=1moving2points \
        n_objects:=1.0 \
        object_0_model_name:=sphere50 \
        object_0_frame:=target"
```

### After
```python
cmd = cmd_utils.construct_roslaunch_command(
    module='ur_robot_server',
    launch_file='ur_robot_server.launch',
    launch_args={
        'world_name': 'tabletop_sphere50.world',
        'reference_frame': 'base_link',
        'max_velocity_scale_factor': 0.2,
        'action_cycle_rate': 20,
        'rviz_gui': False,
        'gazebo_gui': True,
        'objects_controller': True,
        'rs_mode': '1moving2points',
        'n_objects': 1.0,
        'object_0_model_name': 'sphere50',
        'object_0_frame': 'target',
        'ur_model': ur_model
    }
)
```

I haven't checked if this PR works cleanly with the new changes but you can use the test file as a starting reference. Let me know your feedback on this!

Tejas